### PR TITLE
Add PNTA SDK version to device identifiers

### DIFF
--- a/android/src/main/kotlin/io/pnta/pnta_flutter/IdentifyHandler.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/IdentifyHandler.kt
@@ -33,7 +33,7 @@ object IdentifyHandler {
                 }
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
-                        val identifiers = collectIdentifiers(activity)
+                        val identifiers = collectIdentifiers(activity, pntaSdkVersion)
                         val info = mapOf(
                             "project_id" to projectId,
                             "identifier" to deviceToken,
@@ -63,7 +63,7 @@ object IdentifyHandler {
         })
     }
 
-    private suspend fun collectIdentifiers(activity: Activity?): Map<String, Any> = withContext(Dispatchers.IO) {
+    private suspend fun collectIdentifiers(activity: Activity?, pntaSdkVersion: String): Map<String, Any> = withContext(Dispatchers.IO) {
         val locale = Locale.getDefault()
         val name = Build.MANUFACTURER
         val model = Build.MODEL

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/IdentifyHandler.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/IdentifyHandler.kt
@@ -102,6 +102,13 @@ object IdentifyHandler {
                 "Unavailable"
             }
         } ?: "Unavailable"
+        val pntaSdkVersion = try {
+            val pntaPluginPackageName = "io.pnta.pnta_flutter"
+            val pluginPackageInfo = activity?.packageManager?.getPackageInfo(pntaPluginPackageName, 0)
+            pluginPackageInfo?.versionName ?: "Unknown"
+        } catch (e: Exception) {
+            "Unknown"
+        }
 
         mapOf(
             "name" to name,
@@ -117,7 +124,8 @@ object IdentifyHandler {
             "current_time_zone" to currentTimeZone,
             "bundle_identifier" to bundleIdentifier,
             "app_version" to appVersion,
-            "app_build" to appBuild
+            "app_build" to appBuild,
+            "pnta_sdk_version" to pntaSdkVersion
         )
     }
 } 

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/IdentifyHandler.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/IdentifyHandler.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.withContext
 import android.content.Context
 
 object IdentifyHandler {
-    fun identify(activity: Activity?, projectId: String?, metadata: Map<String, Any>?, result: Result) {
+    fun identify(activity: Activity?, projectId: String?, metadata: Map<String, Any>?, pntaSdkVersion: String, result: Result) {
         if (projectId == null) {
             result.error("INVALID_ARGUMENTS", "projectId is null", null)
             return
@@ -102,13 +102,6 @@ object IdentifyHandler {
                 "Unavailable"
             }
         } ?: "Unavailable"
-        val pntaSdkVersion = try {
-            val pntaPluginPackageName = "io.pnta.pnta_flutter"
-            val pluginPackageInfo = activity?.packageManager?.getPackageInfo(pntaPluginPackageName, 0)
-            pluginPackageInfo?.versionName ?: "Unknown"
-        } catch (e: Exception) {
-            "Unknown"
-        }
 
         mapOf(
             "name" to name,

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
@@ -58,11 +58,12 @@ class PntaFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     } else if (call.method == "identify") {
       val projectId = call.argument<String>("projectId")
       val metadata = call.argument<Map<String, Any>>("metadata")
+      val pntaSdkVersion = call.argument<String>("pntaSdkVersion") ?: "Unknown"
       if (projectId == null) {
         result.error("INVALID_ARGUMENTS", "projectId is null", null)
         return
       }
-      IdentifyHandler.identify(activity, projectId, metadata, result)
+      IdentifyHandler.identify(activity, projectId, metadata, pntaSdkVersion, result)
     } else if (call.method == "updateMetadata") {
       val projectId = call.argument<String>("projectId")
       val metadata = call.argument<Map<String, Any>>("metadata")

--- a/ios/Classes/IdentifyHandler.swift
+++ b/ios/Classes/IdentifyHandler.swift
@@ -3,7 +3,7 @@ import Flutter
 import UIKit
 
 class IdentifyHandler {
-    static func identify(projectId: String, metadata: [String: Any]? = nil, result: @escaping FlutterResult) {
+    static func identify(projectId: String, metadata: [String: Any]? = nil, pntaSdkVersion: String, result: @escaping FlutterResult) {
         TokenHandler.getDeviceToken { deviceToken in
             guard let token = deviceToken as? String else {
                 result(FlutterError(code: "NO_TOKEN", message: "Device token not available", details: nil))
@@ -29,7 +29,7 @@ class IdentifyHandler {
                 "bundle_identifier": bundle.bundleIdentifier ?? "Unavailable",
                 "app_version": bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unavailable",
                 "app_build": bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unavailable",
-                "pnta_sdk_version": Self.getPntaSdkVersion()
+                "pnta_sdk_version": pntaSdkVersion
             ]
 
             let info: [String: Any] = [
@@ -45,14 +45,5 @@ class IdentifyHandler {
                 successReturn: token
             )
         }
-    }
-    
-    private static func getPntaSdkVersion() -> String {
-        let pntaPluginBundleId = "io.pnta.pnta_flutter"
-        if let pntaPluginBundle = Bundle(identifier: pntaPluginBundleId),
-           let pntaSdkVersion = pntaPluginBundle.infoDictionary?["CFBundleShortVersionString"] as? String {
-            return pntaSdkVersion
-        }
-        return "Unknown"
     }
 } 

--- a/ios/Classes/IdentifyHandler.swift
+++ b/ios/Classes/IdentifyHandler.swift
@@ -28,7 +28,8 @@ class IdentifyHandler {
                 "current_time_zone": TimeZone.current.identifier,
                 "bundle_identifier": bundle.bundleIdentifier ?? "Unavailable",
                 "app_version": bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unavailable",
-                "app_build": bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unavailable"
+                "app_build": bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unavailable",
+                "pnta_sdk_version": Self.getPntaSdkVersion()
             ]
 
             let info: [String: Any] = [
@@ -44,5 +45,14 @@ class IdentifyHandler {
                 successReturn: token
             )
         }
+    }
+    
+    private static func getPntaSdkVersion() -> String {
+        let pntaPluginBundleId = "io.pnta.pnta_flutter"
+        if let pntaPluginBundle = Bundle(identifier: pntaPluginBundleId),
+           let pntaSdkVersion = pntaPluginBundle.infoDictionary?["CFBundleShortVersionString"] as? String {
+            return pntaSdkVersion
+        }
+        return "Unknown"
     }
 } 

--- a/ios/Classes/PntaFlutterPlugin.swift
+++ b/ios/Classes/PntaFlutterPlugin.swift
@@ -23,7 +23,8 @@ public class PntaFlutterPlugin: NSObject, FlutterPlugin, UIApplicationDelegate {
       if let args = call.arguments as? [String: Any],
          let projectId = args["projectId"] as? String {
         let metadata = args["metadata"] as? [String: Any]
-        IdentifyHandler.identify(projectId: projectId, metadata: metadata, result: result)
+        let pntaSdkVersion = args["pntaSdkVersion"] as? String ?? "Unknown"
+        IdentifyHandler.identify(projectId: projectId, metadata: metadata, pntaSdkVersion: pntaSdkVersion, result: result)
       } else {
         result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing arguments for identify", details: nil))
       }

--- a/lib/pnta_flutter_method_channel.dart
+++ b/lib/pnta_flutter_method_channel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'pnta_flutter_platform_interface.dart';
+import 'src/version.dart';
 
 /// An implementation of [PntaFlutterPlatform] that uses method channels.
 class MethodChannelPntaFlutter extends PntaFlutterPlatform {
@@ -35,6 +36,7 @@ class MethodChannelPntaFlutter extends PntaFlutterPlatform {
       {Map<String, dynamic>? metadata}) async {
     final token = await methodChannel.invokeMethod<String>('identify', {
       'projectId': projectId,
+      'pntaSdkVersion': kPntaSdkVersion,
       if (metadata != null) 'metadata': metadata,
     });
     return token;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,3 @@
+/// PNTA Flutter SDK version
+/// This should match the version in pubspec.yaml
+const String kPntaSdkVersion = '1.0.0-dev.4';


### PR DESCRIPTION
## Summary
- Add `pnta_sdk_version` field to device identifiers
- Version is managed via Dart constant in `lib/src/version.dart`
- Dart passes SDK version to both Android and iOS platforms
- Single source of truth for version management

## Implementation
**Dart:** Creates `kPntaSdkVersion` constant and passes to native methods
**Android:** Receives version via method channel arguments
**iOS:** Receives version via method channel arguments

## Benefits
- Track which PNTA plugin version users are running
- Better debugging and support capabilities
- Analytics on plugin version adoption
- Easy version management - update one Dart file when bumping versions

## Why this approach?
Initially tried reading version from native package info, but Flutter plugins get compiled into the host app, so no separate package exists at runtime. The Dart constant approach is more reliable and easier to maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The SDK version is now included in the identification payload for both Android and iOS platforms.
- **Chores**
  - Added a constant for the SDK version to ensure consistency across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->