### PR TITLE
Add trackOpen method for analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Returns `Future<void>`. Use `PntaFlutter.deviceToken` getter to access the devic
 
 Updates device metadata without re-registering. Must be called after successful initialization. Returns `Future<void>`.
 
+#### `PntaFlutter.trackOpen(Map<String, dynamic> payload)`
+
+Tracks that a notification was opened. Pass the payload you received from `onNotificationTap` or `foregroundNotifications`; its `notification_id` and `token` fields are used. Must be called after `initialize()`. Best-effort — failures are logged, not thrown. Returns `Future<void>`.
+
 #### `PntaFlutter.handleLink(String link)`
 
 Manually handles a link using the plugin's routing logic.

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
@@ -75,6 +75,15 @@ class PntaFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         return
       }
       MetadataHandler.updateMetadata(projectId, metadata, result)
+    } else if (call.method == "trackOpen") {
+      val projectId = call.argument<String>("projectId")
+      val notificationId = call.argument<String>("notificationId")
+      val token = call.argument<String>("token")
+      if (projectId == null || notificationId == null || token == null) {
+        result.error("INVALID_ARGUMENTS", "projectId, notificationId or token is null", null)
+        return
+      }
+      TrackOpenHandler.trackOpen(projectId, notificationId, token, result)
     } else if (call.method == "setForegroundPresentationOptions") {
       val showSystemUI = call.argument<Boolean>("showSystemUI") ?: false
       ForegroundNotificationHandler.setForegroundPresentationOptions(showSystemUI)

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/TrackOpenHandler.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/TrackOpenHandler.kt
@@ -1,0 +1,31 @@
+package io.pnta.pnta_flutter
+
+import android.util.Log
+import io.flutter.plugin.common.MethodChannel.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+object TrackOpenHandler {
+    fun trackOpen(projectId: String, notificationId: String, token: String, result: Result) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val info = mapOf(
+                    "project_id" to projectId,
+                    "token" to token
+                )
+                NetworkUtils.sendPutRequest(
+                    urlString = "https://app.pnta.io/api/v1/notifications/$notificationId/open",
+                    payload = info,
+                    result = result
+                )
+            } catch (e: Exception) {
+                Log.e("TrackOpenHandler", "Error in trackOpen: ${e.localizedMessage}")
+                withContext(Dispatchers.Main) {
+                    result.success(null)
+                }
+            }
+        }
+    }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,6 +51,7 @@ class _HomePageState extends State<HomePage> {
     });
 
     PntaFlutter.onNotificationTap.listen((payload) {
+      PntaFlutter.trackOpen(payload);
       setState(() => _lastNotification = 'Tap: ${payload.toString()}');
     });
   }

--- a/ios/Classes/PntaFlutterPlugin.swift
+++ b/ios/Classes/PntaFlutterPlugin.swift
@@ -37,6 +37,15 @@ public class PntaFlutterPlugin: NSObject, FlutterPlugin, UIApplicationDelegate {
       } else {
         result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing arguments for updateMetadata", details: nil))
       }
+    case "trackOpen":
+      if let args = call.arguments as? [String: Any],
+         let projectId = args["projectId"] as? String,
+         let notificationId = args["notificationId"] as? String,
+         let token = args["token"] as? String {
+        TrackOpenHandler.trackOpen(projectId: projectId, notificationId: notificationId, token: token, result: result)
+      } else {
+        result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing arguments for trackOpen", details: nil))
+      }
     case "setForegroundPresentationOptions":
       if let args = call.arguments as? [String: Any],
          let showSystemUI = args["showSystemUI"] as? Bool {

--- a/ios/Classes/TrackOpenHandler.swift
+++ b/ios/Classes/TrackOpenHandler.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Flutter
+
+class TrackOpenHandler {
+    static func trackOpen(projectId: String, notificationId: String, token: String, result: @escaping FlutterResult) {
+        let info: [String: Any] = [
+            "project_id": projectId,
+            "token": token
+        ]
+        NetworkUtils.sendPutRequest(
+            urlString: "https://app.pnta.io/api/v1/notifications/\(notificationId)/open",
+            payload: info,
+            result: result
+        )
+    }
+}

--- a/lib/pnta_flutter.dart
+++ b/lib/pnta_flutter.dart
@@ -98,6 +98,33 @@ class PntaFlutter {
     }
   }
 
+  /// Track that a notification was opened.
+  ///
+  /// Pass the [payload] you received from [onNotificationTap] or
+  /// [foregroundNotifications]; its `notification_id` and `token` fields are
+  /// used. Best-effort: failures are logged, not thrown.
+  static Future<void> trackOpen(Map<String, dynamic> payload) async {
+    if (_config == null) {
+      debugPrint('PNTA: Must call initialize() before tracking open.');
+      return;
+    }
+    final notificationId = payload['notification_id'] as String?;
+    final token = payload['token'] as String?;
+    if (notificationId == null || token == null) {
+      debugPrint('PNTA: trackOpen needs notification_id and token in the payload.');
+      return;
+    }
+    try {
+      await PntaFlutterPlatform.instance.trackOpen(
+        _config!.projectId,
+        notificationId,
+        token,
+      );
+    } catch (e, st) {
+      debugPrint('PNTA: trackOpen error: $e\n$st');
+    }
+  }
+
   // Notifications
   /// Stream of notifications received while app is in foreground
   static Stream<Map<String, dynamic>> get foregroundNotifications =>

--- a/lib/pnta_flutter.dart
+++ b/lib/pnta_flutter.dart
@@ -111,7 +111,8 @@ class PntaFlutter {
     final notificationId = payload['notification_id'] as String?;
     final token = payload['token'] as String?;
     if (notificationId == null || token == null) {
-      debugPrint('PNTA: trackOpen needs notification_id and token in the payload.');
+      debugPrint(
+          'PNTA: trackOpen needs notification_id and token in the payload.');
       return;
     }
     try {

--- a/lib/pnta_flutter_method_channel.dart
+++ b/lib/pnta_flutter_method_channel.dart
@@ -63,6 +63,15 @@ class MethodChannelPntaFlutter extends PntaFlutterPlatform {
   }
 
   @override
+  Future<void> trackOpen(String projectId, String notificationId, String token) async {
+    await methodChannel.invokeMethod('trackOpen', {
+      'projectId': projectId,
+      'notificationId': notificationId,
+      'token': token,
+    });
+  }
+
+  @override
   Stream<Map<String, dynamic>> get foregroundNotifications {
     _foregroundNotificationsStream ??= _foregroundNotificationsEventChannel
         .receiveBroadcastStream()

--- a/lib/pnta_flutter_method_channel.dart
+++ b/lib/pnta_flutter_method_channel.dart
@@ -63,7 +63,8 @@ class MethodChannelPntaFlutter extends PntaFlutterPlatform {
   }
 
   @override
-  Future<void> trackOpen(String projectId, String notificationId, String token) async {
+  Future<void> trackOpen(
+      String projectId, String notificationId, String token) async {
     await methodChannel.invokeMethod('trackOpen', {
       'projectId': projectId,
       'notificationId': notificationId,

--- a/lib/pnta_flutter_platform_interface.dart
+++ b/lib/pnta_flutter_platform_interface.dart
@@ -50,7 +50,8 @@ abstract class PntaFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('updateMetadata() has not been implemented.');
   }
 
-  Future<void> trackOpen(String projectId, String notificationId, String token) {
+  Future<void> trackOpen(
+      String projectId, String notificationId, String token) {
     throw UnimplementedError('trackOpen() has not been implemented.');
   }
 

--- a/lib/pnta_flutter_platform_interface.dart
+++ b/lib/pnta_flutter_platform_interface.dart
@@ -50,6 +50,10 @@ abstract class PntaFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('updateMetadata() has not been implemented.');
   }
 
+  Future<void> trackOpen(String projectId, String notificationId, String token) {
+    throw UnimplementedError('trackOpen() has not been implemented.');
+  }
+
   /// Emits notification payloads when received while the app is in the foreground.
   Stream<Map<String, dynamic>> get foregroundNotifications {
     throw UnimplementedError(

--- a/test/pnta_flutter_test.dart
+++ b/test/pnta_flutter_test.dart
@@ -26,6 +26,18 @@ class MockPntaFlutterPlatform
   ]) =>
       Future.value();
 
+  String? lastTrackOpenProjectId;
+  String? lastTrackOpenNotificationId;
+  String? lastTrackOpenToken;
+
+  @override
+  Future<void> trackOpen(String projectId, String notificationId, String token) {
+    lastTrackOpenProjectId = projectId;
+    lastTrackOpenNotificationId = notificationId;
+    lastTrackOpenToken = token;
+    return Future.value();
+  }
+
   @override
   Stream<Map<String, dynamic>> get foregroundNotifications => Stream.empty();
 
@@ -50,5 +62,18 @@ void main() {
 
     // Test that deviceToken is accessible via getter
     expect(PntaFlutter.deviceToken, isNull); // Initially null
+  });
+
+  test('trackOpen pulls notification_id and token from the payload', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final fakePlatform = MockPntaFlutterPlatform();
+    PntaFlutterPlatform.instance = fakePlatform;
+
+    await PntaFlutter.initialize('prj_test');
+    await PntaFlutter.trackOpen({'notification_id': 'notif_abc', 'token': 'tok_123'});
+
+    expect(fakePlatform.lastTrackOpenProjectId, 'prj_test');
+    expect(fakePlatform.lastTrackOpenNotificationId, 'notif_abc');
+    expect(fakePlatform.lastTrackOpenToken, 'tok_123');
   });
 }

--- a/test/pnta_flutter_test.dart
+++ b/test/pnta_flutter_test.dart
@@ -31,7 +31,8 @@ class MockPntaFlutterPlatform
   String? lastTrackOpenToken;
 
   @override
-  Future<void> trackOpen(String projectId, String notificationId, String token) {
+  Future<void> trackOpen(
+      String projectId, String notificationId, String token) {
     lastTrackOpenProjectId = projectId;
     lastTrackOpenNotificationId = notificationId;
     lastTrackOpenToken = token;
@@ -70,7 +71,8 @@ void main() {
     PntaFlutterPlatform.instance = fakePlatform;
 
     await PntaFlutter.initialize('prj_test');
-    await PntaFlutter.trackOpen({'notification_id': 'notif_abc', 'token': 'tok_123'});
+    await PntaFlutter.trackOpen(
+        {'notification_id': 'notif_abc', 'token': 'tok_123'});
 
     expect(fakePlatform.lastTrackOpenProjectId, 'prj_test');
     expect(fakePlatform.lastTrackOpenNotificationId, 'notif_abc');


### PR DESCRIPTION
Hookup method to the api/v1/notifications/:id/open endpoint to track open rates

Closes https://github.com/pnta-io/postbox/issues/1359