### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+-   Add trackOpen method for notification open analytics
+
 ## 1.1.1
 
 -   Fix build error by removing deprecated PluginRegistry.Registrar import

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pnta_flutter
 description: "Official PNTA Flutter plugin to make push notifications suck less."
-version: 1.1.1
+version: 1.2.0
 homepage: https://pnta.io
 repository: https://github.com/pnta-io/pnta-flutter-plugin
 documentation: https://docs.pnta.io


### PR DESCRIPTION
Prepares the 1.2.0 release. Bumps the version in pubspec.yaml and adds the changelog entry for the new trackOpen method.

Ill change the existing tag to point to this commit when i merge